### PR TITLE
Fix relative paths

### DIFF
--- a/src/acme/handlers/mod.rs
+++ b/src/acme/handlers/mod.rs
@@ -82,7 +82,7 @@ impl HandlerState {
             .header(REPLAY_NONCE_HEADER, self.clone().nonce.unwrap())
             .header(
                 "Link",
-                format!(r#"<{}>;rel="index""#, url.join("/")?.to_string()),
+                format!(r#"<{}>;rel="index""#, url.join("./")?.to_string()),
             ))
     }
 }

--- a/src/acme/handlers/order.rs
+++ b/src/acme/handlers/order.rs
@@ -333,7 +333,7 @@ pub(crate) async fn finalize_order(
                 Err(e) => return Err(ACMEValidationError::Other(e.to_string()).into()),
             };
 
-            let url = uri_to_url(appstate.clone().baseurl, req.uri().clone()).await?;
+            let url = appstate.clone().baseurl;
             let h_order = serde_json::to_string(&order.clone().into_handler_order(url.clone())?)?;
 
             return Ok((

--- a/src/acme/handlers/order.rs
+++ b/src/acme/handlers/order.rs
@@ -137,7 +137,7 @@ pub(crate) async fn new_order(
                 }
             }
 
-            let url = uri_to_url(appstate.clone().baseurl, req.uri().clone()).await?;
+            let url = appstate.clone().baseurl;
 
             let order: Order =
                 crate::models::order::Order::find(o.id()?.unwrap(), appstate.db.clone())
@@ -186,7 +186,7 @@ pub(crate) async fn existing_order(
             )
             .await?;
 
-            let url = uri_to_url(appstate.clone().baseurl, req.uri().clone()).await?;
+            let url = appstate.clone().baseurl;
             let h_order = serde_json::to_string(&o.clone().into_handler_order(url.clone())?)?;
 
             return Ok((
@@ -523,12 +523,9 @@ pub(crate) async fn post_authz(
 
             let mut statuscode = StatusCode::CREATED;
 
-            let authz = Authorization::from_authorization_id(
-                auth_id,
-                uri_to_url(appstate.clone().baseurl, req.uri().clone()).await?,
-                &tx,
-            )
-            .await?;
+            let authz =
+                Authorization::from_authorization_id(auth_id, appstate.clone().baseurl, &tx)
+                    .await?;
             for chall in authz.clone().challenges {
                 if chall.status == OrderStatus::Valid {
                     statuscode = StatusCode::OK;
@@ -606,7 +603,10 @@ pub(crate) async fn post_challenge(
                 Some(
                     builder
                         .body(Body::from(serde_json::to_string(
-                            &ChallengeAuthorization::from_challenge(&ch, ch.into_url(url))?,
+                            &ChallengeAuthorization::from_challenge(
+                                &ch,
+                                ch.into_url(appstate.clone().baseurl),
+                            )?,
                         )?))
                         .unwrap(),
                 ),

--- a/src/models/order.rs
+++ b/src/models/order.rs
@@ -136,12 +136,12 @@ impl Order {
                 None
             },
             finalize: Some(
-                url.join(&format!("/order/{}/finalize", self.order_id))
+                url.join(&format!("./order/{}/finalize", self.order_id))
                     .unwrap(),
             ),
             // FIXME this needs to be at a unique location, not related to the order id
             certificate: Some(
-                url.join(&format!("/order/{}/certificate", self.order_id))
+                url.join(&format!("./order/{}/certificate", self.order_id))
                     .unwrap(),
             ),
         };
@@ -444,7 +444,7 @@ impl Challenge {
     }
 
     pub(crate) fn into_url(&self, url: url::Url) -> url::Url {
-        url.join(&format!("/chall/{}", self.reference)).unwrap()
+        url.join(&format!("./chall/{}", self.reference)).unwrap()
     }
 
     fn new_from_row(result: &Row) -> Result<Self, LoadError> {
@@ -731,7 +731,9 @@ impl Authorization {
     }
 
     pub fn into_url(&self, baseurl: Url) -> Url {
-        baseurl.join(&format!("/authz/{}", self.reference)).unwrap()
+        baseurl
+            .join(&format!("./authz/{}", self.reference))
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
If baseurl with an existing path on App, don't overwrite it, just append to it.

Problem is that if baseurl is "https://hostname/acme/" the response to https://hostname/acme/order would return an Order with in part:
```
"authorizations": [
    "https://hostname/authz/:ID"
  ],
```
when it should be "https://hostname/acme/authz/..."