### PR TITLE
CA: Use openssl extensions instead of manually creating

### DIFF
--- a/src/acme/ca.rs
+++ b/src/acme/ca.rs
@@ -90,7 +90,7 @@ impl CA {
             None,
             Some(&builder.x509v3_context(None, None)),
             "extendedKeyUsage",
-            "critical,serverAuth",
+            "critical,serverAuth,clientAuth",
         )?)?;
 
         builder.append_extension(X509Extension::new(


### PR DESCRIPTION
Use `openssl::X509::extension::*` where available instead of manually building `X509Extension`.

Add ClientAuth to ExtendedKeyUsage