### PR TITLE
Allow `Challenger::tick` to take async callback.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,7 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "ratpack"
-version = "0.1.3"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e31ecc7a02e6bebabaebb9dba5ee5bc63d2ac9333a8d502b1f116f8e221d9f"
 dependencies = [
  "async-recursion",
  "http",

--- a/examples/acmed.rs
+++ b/examples/acmed.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), ServerError> {
     tokio::spawn(async move {
         loop {
             // FIXME whitelist all challenge requests. This is not how ACME is supposed to work. You have to write this.
-            c2.tick(|_c| Some(())).await;
+            c2.tick(|_c| async { Some(()) }).await;
             // NOTE this will explode violently if it unwraps to error, e.g. if the db goes down.
             c2.reconcile(pg2.clone()).await.unwrap();
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -242,7 +242,7 @@ impl TestService {
 
         tokio::spawn(async move {
             loop {
-                c2.tick(|_c| Some(())).await;
+                c2.tick(|_c| async { Some(()) }).await;
                 c2.reconcile(pg2.clone()).await.unwrap();
 
                 tokio::time::sleep(Duration::new(0, 250)).await;


### PR DESCRIPTION
There are cases where we may want to do some async work in the `Challenger::tick` callback. Since `Challenger::tick` itself is async, it's trivial to make the callback async as well.

This allows users to do non-blocking work inside the callback.